### PR TITLE
Add brackets and houses to clubhouse

### DIFF
--- a/ch-gh-string/source.js
+++ b/ch-gh-string/source.js
@@ -2,4 +2,4 @@
 // @name Clubhouse Github parse string bookmarklet
 // @author Andres Cuervo
 // ==/Bookmarklet==
-var clipEl = document.querySelector('[id^=story-id]'); clipEl.value=`[ch${clipEl.id.match(/\d+/)[0]}](${document.location.href})`
+var clipEl = document.querySelector('[id^=story-id]'); clipEl.value=`[:house: [ch${clipEl.id.match(/\d+/)[0]}]](${document.location.href})`


### PR DESCRIPTION
Clubhouse seems to receive a markup-removed version of the PR, and the existing brackets are part of the markup for the link so get removed. Adding a set of brackets inside the link seems to fix it. Also, add a :house:.